### PR TITLE
get_tags: Handle not existed repo

### DIFF
--- a/lib/regiui.py
+++ b/lib/regiui.py
@@ -83,8 +83,13 @@ class Repository(object):
 
     def get_tags(self):
         # Get tag names from registry
-        res = self.api.call("GET", "%s/tags/list" % self.name)
-        tags = json.load(res)["tags"] or []
+        try:
+            res = self.api.call("GET", "%s/tags/list" % self.name)
+            tags = json.load(res).get("tags", [])
+        except urllib2.HTTPError as exc:
+            if exc.code != 404:
+                raise exc
+            tags = []
         return sorted(tags)
 
     def get_tags_by_digest(self, content_digest):


### PR DESCRIPTION
HTTPError will raise in `urllib2.urlopen` if a 404 response.

```
$ http http://registry.arpanet/v2/xx-xxx/tags/list

HTTP/1.1 404 Not Found
Connection: keep-alive
Content-Length: 121
Content-Type: application/json; charset=utf-8
Date: Mon, 10 Apr 2017 06:08:03 GMT
Docker-Distribution-Api-Version: registry/2.0
Server: nginx
X-Content-Type-Options: nosniff

{
    "errors": [
        {
            "code": "NAME_UNKNOWN",
            "detail": {
                "name": "xx-xxx"
            },
            "message": "repository name not known to registry"
        }
    ]
}
```